### PR TITLE
Hotfix permissions view only access

### DIFF
--- a/redash/models/parameterized_query.py
+++ b/redash/models/parameterized_query.py
@@ -183,8 +183,11 @@ class ParameterizedQuery(object):
 
     @property
     def is_safe(self):
-        text_parameters = [param for param in self.schema if param["type"] == "text"]
-        return not any(text_parameters)
+        # text_parameters = [param for param in self.schema if param["type"] == "text"]
+        # return not any(text_parameters)
+        # Changed to be able to execute queries with a text field for view only users
+        # even we have a possible issue with query injection.
+        return True
 
     @property
     def missing_params(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ x] Other

## Description
    
    Read only access to databases does not allow execute queries with
    a text field. We have changed it to allow that type of query for
    CS external teams so they do not need a full access.
    
    IMPORTANT Take into account that now read only access allows
    query injection.

